### PR TITLE
Add Linux Support

### DIFF
--- a/csgo/csgo.py
+++ b/csgo/csgo.py
@@ -10,6 +10,8 @@ import pyautogui as gui
 try:
     import pydirectinput as user
 except ImportError:
+    # pyautogui provides the same API as pydirectinput,
+    # at least for the calls made in this harness
     import pyautogui as user
 from utils import (
     get_resolution,

--- a/csgo/csgo.py
+++ b/csgo/csgo.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Counter Strike: Global Offensive test script"""
 import logging
 import os
@@ -5,7 +7,10 @@ import time
 import sys
 from argparse import ArgumentParser
 import pyautogui as gui
-import pydirectinput as user
+try:
+    import pydirectinput as user
+except ImportError:
+    import pyautogui as user
 from utils import (
     get_resolution,
     benchmark_folder_exists,

--- a/csgo/csgo.py
+++ b/csgo/csgo.py
@@ -102,7 +102,7 @@ def run_benchmark():
     logging.info("Benchmark took %.2f seconds", elapsed_test_time)
 
     terminate_processes(PROCESS_NAME)
-    return start_time, end_time
+    return test_start_time, test_end_time
 
 
 # Entry Point

--- a/cyberpunk2077/cyberpunk2077.py
+++ b/cyberpunk2077/cyberpunk2077.py
@@ -1,10 +1,16 @@
+#!/usr/bin/env python3
+
 """Cyberpunk 2077 test script"""
 import time
 import logging
 import sys
 import os
 import pyautogui as gui
-import pydirectinput as user
+
+try:
+    import pydirectinput as user
+except ImportError:
+    import pyautogui as user
 from cyberpunk_utils import copy_no_intro_mod, get_args, read_current_resolution
 
 

--- a/harness_utils/steam.py
+++ b/harness_utils/steam.py
@@ -5,6 +5,8 @@ import shutil
 if os.name == 'nt':
     import winreg
 else:
+    # If we don't have a registry, then
+    # we need to parse Valve's data files
     import vdf
 from subprocess import Popen
 from pathlib import Path
@@ -30,28 +32,37 @@ def get_steam_folder_path() -> str:
         return os.path.expanduser("~/.steam/steam")
 
 
-def get_steam_exe() -> str | list[str]:
+def get_steam_exe() -> list[str]:
     """
     On Windows, gets the path to the Steam executable from the SteamExe registry key.
 
     On Linux, we first use :code:`which` to check if the system-wide version of Steam
     is installed. If not, we then check if the flatpak is installed, and finally if the
     snap is installed.
+
+    :return: The command to invoke Steam, as a :obj:`Popen`
+             style list.
     """
     if os.name == 'nt':
         reg_path = r"Software\Valve\Steam"
         reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, reg_path, 0, winreg.KEY_READ)
         value, _ = winreg.QueryValueEx(reg_key, "SteamExe")
-        return value
+        return [value]
     else:
+        # First check if steam is on the PATH
         steam_path = shutil.which("steam")
         if steam_path is not None:
-            return steam_path
+            return [steam_path]
         else:
+            # Steam not on PATH, check if there is flatpak
             flatpak_path = shutil.which("flatpak")
             if flatpak_path is not None:
+                # Windows code assumes Steam is installed, so don't bother verifying
                 return [flatpak_path, "run", "com.valvesoftware.Steam"]
             else:
+                # If not installed system-wide and there's no flatpak,
+                # then it must be installed through Snap, but we'll check
+                # for the existence of Snap anyway just in case
                 snap_path = shutil.which("snap")
                 if snap_path is not None:
                     return [snap_path, "run", "steam"]
@@ -80,7 +91,7 @@ def get_app_install_location(app_id: int) -> str:
     """
     Given the Steam App ID, Gets the install directory from the Windows Registry
 
-    On Linux, parses the libraryfolders.vdf folder to find the app install location.
+    On Linux, parses the libraryfolders.vdf file to find the app install location.
     """
 
     if os.name == 'nt':
@@ -90,6 +101,34 @@ def get_app_install_location(app_id: int) -> str:
         winreg.CloseKey(registry_key)
         return value
     else:
+        # libraryfolders.vdf contains information on the different Steam
+        # libraries and what games / apps each library contains.
+        #
+        # The file format is VDF (Valve Data File). It is a key-value
+        # format similar to JSON. The VDF library parses this format
+        # and returns a dictionary-like object. VDF can have multiple
+        # entries with the same key, so the returned object is not
+        # a true dict.
+        #
+        # The libraryfolders.vdf file is structured in the following hierarchy:
+        #
+        # - "libraryfolders":
+        #   - "<index>":
+        #       "path": "<library base path>",
+        #       "apps":
+        #           "<app_id>": "<size in bytes>"
+        #           ...
+        #
+        # There are many more keys, but these are the ones we are interested in.
+        # Inside each library, underneath the "steamapps" directory, there is an
+        # "appmanifest_<app_id>.acf" file for each install app. This file
+        # is also a VDF-formatted file, and we are interested in the following keys:
+        #
+        # - "AppState":
+        #   - "installdir": "<directory_name>"
+        #
+        # The installdir is a directory path relative to the library's "steamapps/common" directory.
+        # Therefore, we combine all these pieces to return that absolute path.
         with open(Path(get_steam_folder_path()) / "config" / "libraryfolders.vdf") as f:
             database = vdf.load(f)
             folders = database["libraryfolders"]
@@ -102,7 +141,7 @@ def get_app_install_location(app_id: int) -> str:
                         return (lib_folder / "steamapps" / "common" / app_database["AppState"]["installdir"]).absolute()
 
 
-def exec_steam_run_command(game_id: int, steam_command: str | list = None) -> Popen:
+def exec_steam_run_command(game_id: int, steam_command: list[str] = None) -> Popen:
     """Runs a game using the Steam browser protocol. The `steam_path` argument can be used to
     specify a specifc path to the Steam executable instead of relying on finding the current
     installation in the Window's registry.
@@ -113,23 +152,18 @@ def exec_steam_run_command(game_id: int, steam_command: str | list = None) -> Po
     steam_run_arg = "steam://rungameid/" + str(game_id)
     if steam_command is None:
         steam_command = get_steam_exe()
-    logging.info("%s %s", steam_command, steam_run_arg)
-    if isinstance(steam_command, str):
-        return Popen([steam_command, steam_run_arg])
-    else:
-        steam_command.append(steam_run_arg)
-        return Popen(steam_command)
+    logging.info("%s %s", [" ".join(arg) for arg in steam_command], steam_run_arg)
+    steam_command.append(steam_run_arg)
+    return Popen(steam_command)
 
 
-def exec_steam_game(game_id: int, steam_path=None, game_params=None) -> Popen:
+def exec_steam_game(game_id: int, steam_command: list[str] = (), game_params: list[str] = ()) -> Popen:
     """Runs a game by providing steam executable with an array of parameters.
     The `steam_path` argument can be used to specify a specifc path to the Steam executable
     instead of relying on finding the current installation in the Window's registry.
     """
-    if steam_path is None:
-        steam_path = get_steam_exe()
-    if game_params is None:
-        game_params = []
-    command = [steam_path, "-applaunch", str(game_id)] + game_params
+    if len(steam_command) == 0:
+        steam_command = get_steam_exe()
+    command = steam_command + ["-applaunch", str(game_id)] + game_params
     logging.info(", ".join(command))
     return Popen(command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ protobuf = "^4.21.2"
 WMI = {version = "^1.5.1", platform = "win32"}
 mss = "^7.0.1"
 requests = "^2.28.2"
+vdf = {version = "^3.4", platform = "linux"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ authors = []
 
 [tool.poetry.dependencies]
 python = "^3.10"
-pywinauto = "0.6.8"
+pywinauto = {version = "0.6.8", platform = "win32"}
 pyyaml = "6.0"
 python-dotenv = "0.20.0"
 pyfiglet = "0.8.post1"
 PyAutoGUI = "^0.9.53"
-PyDirectInput = "^1.0.4"
+PyDirectInput = {version = "^1.0.4", platform = "win32"}
 opencv-python = "^4.5.5"
 Pillow = "^9.1.1"
 psutil = "^5.9.1"
@@ -19,7 +19,7 @@ pandas = "^1.4.2"
 imutils = "^0.5.4"
 matplotlib = "^3.5.2"
 protobuf = "^4.21.2"
-WMI = "^1.5.1"
+WMI = {version = "^1.5.1", platform = "win32"}
 mss = "^7.0.1"
 requests = "^2.28.2"
 


### PR DESCRIPTION
This PR adds initial Linux support to these test harnesses.

Not all harnesses and features will work on Linux, to be clear. So far, I have the CS:GO benchmark working up until the game start detection. Since CS:GO recently was updated to CS:2, there is no longer a News icon for Markbench to detect, so it hangs there. I commented out those lines locally, and it proceeded further, making it into the map automatically and attempting to start the benchmark. The benchmark command was not found, but I verified the files were copied to the correct location, so it may have something to do with the recent update.

**TODO**

- [ ] Add Linux codepaths for other utility functions
- [ ] Buy Cyberpunk (*woohoo*) to get that test running next
- [ ] Add documentation for Linux installation and usage

**Note**
I understand you are not accepting contributions at this time. However, I felt it was important for the Linux gaming community to add support as quickly as possible. Even if these changes are not merged, having these harnesses working on Linux gives us a jumping-off point for making the rest of Markbench work on Linux, once it is released.