### PR TITLE
fix: use pyyaml 6.0.1 to overcome CPython error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = []
 [tool.poetry.dependencies]
 python = "^3.10"
 pywinauto = "0.6.8"
-pyyaml = "6.0"
+pyyaml = "6.0.1"
 python-dotenv = "0.20.0"
 pyfiglet = "0.8.post1"
 PyAutoGUI = "^0.9.53"


### PR DESCRIPTION
Fixes #5 

`pyyaml` had an error on the release of 6.0 to do with CPython. This was fixed in 6.0.1