### PR TITLE
relax error check on cinebench return code

### DIFF
--- a/cinebench_2024/cinebench.py
+++ b/cinebench_2024/cinebench.py
@@ -77,8 +77,7 @@ try:
             out, _ = proc.communicate()
 
             if proc.returncode > 0:
-                logging.error("Cinebench exited with return code %d", proc.returncode)
-                sys.exit(proc.returncode)
+                logging.warning("Cinebench exited with return code %d", proc.returncode)
 
             score = get_score(out)
             if score is None:


### PR DESCRIPTION
- Workaround for edge case where sub process running Cinebench returns a non-zero exit code but completes successfully; Check is somewhat redundant as failure to generate score also results in test failure