### PR TITLE
Tiny tinas harness fix

### DIFF
--- a/tinytinaswonderland/manifest.yaml
+++ b/tinytinaswonderland/manifest.yaml
@@ -1,10 +1,7 @@
 friendly_name: "Tiny Tina's Wonderlands"
 executable: "tinytinaswonderland.py"
 process_name: "Wonderlands.exe"
-# default recording delay to reduce capturing menus during setup, this should be revisited every test bench as loading times may be different 
-recording_delay: 75
-asset_paths:
-  - "harness/tinytinaswonderland/run"
+output_dir: "run"
 options:
   - name: kerasHost
     type: input


### PR DESCRIPTION
updated the manifest file so that the output directory matches the current format expected by markbench