### PR TITLE
Evolve Benchmark work-graph argument typo

### DIFF
--- a/evolve/evolve.py
+++ b/evolve/evolve.py
@@ -45,7 +45,7 @@ def setup_logging():
     logging.getLogger("").addHandler(console)
 
 
-TRACE_MODES = ["pipeline", "inline", "workgraph"]
+TRACE_MODES = ["pipeline", "inline", "work-graph"]
 RENDERERS = ["ray-tracing", "path-tracing"]
 
 

--- a/evolve/manifest.yaml
+++ b/evolve/manifest.yaml
@@ -15,4 +15,4 @@ options:
     values:
       - "pipeline"
       - "inline"
-      - "workgraph"
+      - "work-graph"


### PR DESCRIPTION
Evolve is expecting `work-graph` and not `workgraph` for `--mode`.