### PR TITLE
Increase timeout for OCR 'recap'

### DIFF
--- a/alanwake2/alanwake2.py
+++ b/alanwake2/alanwake2.py
@@ -155,7 +155,7 @@ def run_benchmark():
     logging.info("Harness setup took %f seconds", elapsed_setup_time)
 
     # Starting the benchmark:
-    if kerasService.wait_for_word(word="recap", timeout=60, interval=0.5) is None:
+    if kerasService.wait_for_word(word="recap", timeout=80, interval=0.5) is None:
         logging.error("Didn't see the word recap. Did the save game load?")
         sys.exit(1)
 


### PR DESCRIPTION
Loading is taking longer on some AMD cards on MAYGPUUPDATE-2026 so increasing timeout 60 -> 80 seconds to give the game some time to load.