### PR TITLE
Add score field to Evolve harness report.json

### DIFF
--- a/evolve/evolve.py
+++ b/evolve/evolve.py
@@ -128,6 +128,7 @@ def main():
         "start_time": seconds_to_milliseconds(start_time),
         "end_time": seconds_to_milliseconds(end_time),
         "unit": "Score",
+        "score": scores["Ray tracing"], # Just using Ray Tracing as score field for now. Need to process other score values later.
         "Raytracing": scores["Ray tracing"],
         "Acceleration Structure Builds": scores["Acceleration Structure Builds"],
         "Rasterization": scores["Rasterization"],


### PR DESCRIPTION
- Add score to `report.json` as a workaround for how harness scores are harnesses are currently handled by internal reporting.