### PR TITLE
Use PyAutoGUI for Windows mouse input

### DIFF
--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -190,7 +190,7 @@ def write(text: str) -> None:
 def click(
     x: int | None = None,
     y: int | None = None,
-    hold: float = 0.1,
+    hold: float = 0.2,
     pre_click_delay: float = 0.2,
 ) -> None:
     """Optionally move the pointer, then wait before and after clicking."""

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -82,11 +82,10 @@ def _scale_linux_click_coordinates(x: int, y: int) -> tuple[int, int]:
 
 class _WindowsInputBackend:
     def __init__(self) -> None:
-        import pyautogui as gui
-
+        self._pyautogui = importlib.import_module("pyautogui")
         self._pydirectinput = importlib.import_module("pydirectinput")
         vars(self._pydirectinput)["FAILSAFE"] = False
-        gui.FAILSAFE = False
+        vars(self._pyautogui)["FAILSAFE"] = False
 
     def press(self, key: str) -> None:
         self._pydirectinput.press(key)
@@ -104,16 +103,12 @@ class _WindowsInputBackend:
         self._pydirectinput.moveTo(x=x, y=y)
 
     def click_at_cursor(self, hold: float = 0.1) -> None:
-        import pyautogui as gui
-
-        gui.mouseDown()
+        self._pyautogui.mouseDown()
         time.sleep(hold)
-        gui.mouseUp()
+        self._pyautogui.mouseUp()
 
     def scroll(self, scroll_amount: int) -> None:
-        import pyautogui as gui
-
-        gui.vscroll(scroll_amount)
+        self._pyautogui.vscroll(scroll_amount)
 
 
 class _YdotoolInputBackend:

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -100,7 +100,7 @@ class _WindowsInputBackend:
     def move_mouse(self, x: int, y: int) -> None:
         self._pydirectinput.moveTo(x=x, y=y)
 
-    def click_at_cursor(self, hold: float = 0.2) -> None:
+    def click_at_cursor(self, hold: float = 0.1) -> None:
         import pyautogui as gui
 
         gui.FAILSAFE = False
@@ -158,7 +158,7 @@ class _YdotoolInputBackend:
         time.sleep(0.1)
         self._run("mousemove", str(scaled_x), str(scaled_y))
 
-    def click_at_cursor(self, hold: float = 0.2) -> None:
+    def click_at_cursor(self, hold: float = 0.1) -> None:
         self._run("click", "0x40")
         time.sleep(hold)
         self._run("click", "0x80")
@@ -193,7 +193,7 @@ def write(text: str) -> None:
 def click(
     x: int | None = None,
     y: int | None = None,
-    hold: float = 0.2,
+    hold: float = 0.1,
     pre_click_delay: float = 0.2,
 ) -> None:
     """Optionally move the pointer, then wait before and after clicking."""

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -190,7 +190,7 @@ def write(text: str) -> None:
 def click(
     x: int | None = None,
     y: int | None = None,
-    hold: float = 0.0,
+    hold: float = 0.1,
     pre_click_delay: float = 0.2,
 ) -> None:
     """Optionally move the pointer, then wait before and after clicking."""

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -102,7 +102,7 @@ class _WindowsInputBackend:
     def move_mouse(self, x: int, y: int) -> None:
         self._pydirectinput.moveTo(x=x, y=y)
 
-    def click_at_cursor(self, hold: float = 0.1) -> None:
+    def click_at_cursor(self, hold: float = 0.2) -> None:
         self._pyautogui.mouseDown()
         time.sleep(hold)
         self._pyautogui.mouseUp()
@@ -155,7 +155,7 @@ class _YdotoolInputBackend:
         time.sleep(0.1)
         self._run("mousemove", str(scaled_x), str(scaled_y))
 
-    def click_at_cursor(self, hold: float = 0.1) -> None:
+    def click_at_cursor(self, hold: float = 0.2) -> None:
         self._run("click", "0x40")
         time.sleep(hold)
         self._run("click", "0x80")
@@ -190,7 +190,7 @@ def write(text: str) -> None:
 def click(
     x: int | None = None,
     y: int | None = None,
-    hold: float = 0.1,
+    hold: float = 0.2,
     pre_click_delay: float = 0.2,
 ) -> None:
     """Optionally move the pointer, then wait before and after clicking."""

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -100,11 +100,13 @@ class _WindowsInputBackend:
     def move_mouse(self, x: int, y: int) -> None:
         self._pydirectinput.moveTo(x=x, y=y)
 
-    def click_at_cursor(self) -> None:
+    def click_at_cursor(self, hold: float = 0.2) -> None:
         import pyautogui as gui
 
         gui.FAILSAFE = False
-        gui.click()
+        gui.mouseDown()
+        time.sleep(hold)
+        gui.mouseUp()
 
     def scroll(self, scroll_amount: int) -> None:
         import pyautogui as gui
@@ -156,9 +158,9 @@ class _YdotoolInputBackend:
         time.sleep(0.1)
         self._run("mousemove", str(scaled_x), str(scaled_y))
 
-    def click_at_cursor(self) -> None:
+    def click_at_cursor(self, hold: float = 0.2) -> None:
         self._run("click", "0x40")
-        time.sleep(0.2)
+        time.sleep(hold)
         self._run("click", "0x80")
 
     def scroll(self, scroll_amount: int) -> None:
@@ -191,13 +193,14 @@ def write(text: str) -> None:
 def click(
     x: int | None = None,
     y: int | None = None,
+    hold: float = 0.2,
     pre_click_delay: float = 0.2,
 ) -> None:
     """Optionally move the pointer, then wait before and after clicking."""
     if x is not None and y is not None:
         _backend.move_mouse(x, y)
     time.sleep(pre_click_delay)
-    _backend.click_at_cursor()
+    _backend.click_at_cursor(hold)
     time.sleep(pre_click_delay)
 
 

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -101,7 +101,10 @@ class _WindowsInputBackend:
         self._pydirectinput.moveTo(x=x, y=y)
 
     def click_at_cursor(self) -> None:
-        self._pydirectinput.click()
+        import pyautogui as gui
+
+        gui.FAILSAFE = False
+        gui.click()
 
     def scroll(self, scroll_amount: int) -> None:
         import pyautogui as gui

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -82,8 +82,11 @@ def _scale_linux_click_coordinates(x: int, y: int) -> tuple[int, int]:
 
 class _WindowsInputBackend:
     def __init__(self) -> None:
+        import pyautogui as gui
+
         self._pydirectinput = importlib.import_module("pydirectinput")
         vars(self._pydirectinput)["FAILSAFE"] = False
+        gui.FAILSAFE = False
 
     def press(self, key: str) -> None:
         self._pydirectinput.press(key)
@@ -103,7 +106,6 @@ class _WindowsInputBackend:
     def click_at_cursor(self, hold: float = 0.1) -> None:
         import pyautogui as gui
 
-        gui.FAILSAFE = False
         gui.mouseDown()
         time.sleep(hold)
         gui.mouseUp()

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -100,10 +100,8 @@ class _WindowsInputBackend:
     def move_mouse(self, x: int, y: int) -> None:
         self._pydirectinput.moveTo(x=x, y=y)
 
-    def click_at_cursor(self, hold: float = 0.0) -> None:
-        self._pydirectinput.mouseDown()
-        time.sleep(hold)
-        self._pydirectinput.mouseUp()
+    def click_at_cursor(self) -> None:
+        self._pydirectinput.click()
 
     def scroll(self, scroll_amount: int) -> None:
         import pyautogui as gui
@@ -155,9 +153,9 @@ class _YdotoolInputBackend:
         time.sleep(0.1)
         self._run("mousemove", str(scaled_x), str(scaled_y))
 
-    def click_at_cursor(self, hold: float = 0.0) -> None:
+    def click_at_cursor(self) -> None:
         self._run("click", "0x40")
-        time.sleep(hold)
+        time.sleep(0.2)
         self._run("click", "0x80")
 
     def scroll(self, scroll_amount: int) -> None:
@@ -190,14 +188,13 @@ def write(text: str) -> None:
 def click(
     x: int | None = None,
     y: int | None = None,
-    hold: float = 0.2,
     pre_click_delay: float = 0.2,
 ) -> None:
     """Optionally move the pointer, then wait before and after clicking."""
     if x is not None and y is not None:
         _backend.move_mouse(x, y)
     time.sleep(pre_click_delay)
-    _backend.click_at_cursor(hold)
+    _backend.click_at_cursor()
     time.sleep(pre_click_delay)
 
 

--- a/harness_utils/input.py
+++ b/harness_utils/input.py
@@ -100,7 +100,7 @@ class _WindowsInputBackend:
         self._pydirectinput.keyUp(key)
 
     def move_mouse(self, x: int, y: int) -> None:
-        self._pydirectinput.moveTo(x=x, y=y)
+        self._pyautogui.moveTo(x=x, y=y)
 
     def click_at_cursor(self, hold: float = 0.2) -> None:
         self._pyautogui.mouseDown()


### PR DESCRIPTION
Use PyAutoGUI for Windows mouse movement and separate mouseDown/mouseUp events. Keep PyDirectInput for keyboard input only.

Restore a configurable 0.2-second hold sleep and preserve the 0.2-second pre/post-click pauses. Both libraries are loaded once through importlib; normal library pauses remain enabled.

Static checks only; no tests or input executed.